### PR TITLE
Fix MongoDB error Unknown modifier: $pushAll

### DIFF
--- a/Lyrical-GraphQL/server/models/song.js
+++ b/Lyrical-GraphQL/server/models/song.js
@@ -11,6 +11,8 @@ const SongSchema = new Schema({
     type: Schema.Types.ObjectId,
     ref: 'lyric'
   }]
+  }, {
+  usePushEach: true
 });
 
 SongSchema.statics.addLyric = function(id, content) {


### PR DESCRIPTION
When running the following GraphQL query:
```
mutation {
  addLyricToSong(songId: "5af29df7c084014b34d2bb8a", content: "Oh my oh my its a cold night"){
    id
  }
}
```
This error is returned from my locally hosted MongoDB:
```
{
  "data": {
    "addLyricToSong": null
  },
  "errors": [
    {
      "message": "Unknown modifier: $pushAll",
      "locations": [
        {
          "line": 9,
          "column": 3
        }
      ],
      "path": [
        "addLyricToSong"
      ]
    }
  ]
}
```

Adding {usePushEach: true} solves the problem. Ref: https://medium.com/@stefanledin/how-to-solve-the-unknown-modifier-pushall-error-in-mongoose-d631489f85c0